### PR TITLE
Fix 404 errors

### DIFF
--- a/src/background/action-creators/repo-select.js
+++ b/src/background/action-creators/repo-select.js
@@ -75,7 +75,8 @@ export function startErase (payload) {
   }
 }
 
-export function changeRepo (repoPath) {
+export function changeRepo (payload) {
+  const repoPath = payload.payload
   console.log('changeRepo request received with url ' + 'https://github.com/' + repoPath + '.git')
   return async function (dispatch) {
     console.log('thunk started')

--- a/src/popup/action-creators/repo-select.js
+++ b/src/popup/action-creators/repo-select.js
@@ -3,6 +3,6 @@ import { CHANGE_REPO } from '../../constants'
 export function changeRepo (payload) {
   return {
     type: CHANGE_REPO,
-    ...payload
+    payload
   }
 }


### PR DESCRIPTION
- remove ellipsis syntax from action creator (ellipsis syntax
  expands iterables into argument lists)
- modifiy repo-select action creator to read the payload key

I looked at the console output and it was saying stuff like `changeRepo request received with url https://github.com/[Object object].git`. Silly javascript smh

the ellipsis syntax turned the string input into a list of characters